### PR TITLE
fix(draft-text): 修正字體，字型，顏色的onEditChange BUG

### DIFF
--- a/server/meep-draft/draft-text.react.js
+++ b/server/meep-draft/draft-text.react.js
@@ -263,13 +263,13 @@ export default class DraftText extends Component {
 
   componentDidUpdate(prevProps, prevState) {
     // 判斷每個block中文字的style是否改變，是的話：call onEditorChange()
-    let thisBlockMap = this.state.editorState.toJS().currentContent.blockMap;
-    let prevBlockMap = prevState.editorState.toJS().currentContent.blockMap;
+    let currBlockMap = this.state.editorState.getImmutable().getIn(['currentContent', 'blockMap']);
+    let prevBlockMap = prevState.editorState.getImmutable().getIn(['currentContent', 'blockMap']);
     let isStyleChanged;
-    if(Object.keys(thisBlockMap).length === Object.keys(prevBlockMap).length) {
+    if(currBlockMap.size === prevBlockMap.size) {
       // no newline
-      Object.keys(thisBlockMap).map(key => {
-        if(thisBlockMap[key].text === prevBlockMap[key].text && !deepEqual(thisBlockMap[key].characterList, prevBlockMap[key].characterList)) {
+      currBlockMap.mapKeys(key => {
+        if(currBlockMap.getIn([key, 'text']) === prevBlockMap.getIn([key, 'text']) && currBlockMap.getIn([key, 'characterList']) !== prevBlockMap.getIn([key, 'characterList'])) {
           // style change
           isStyleChanged = true;
         } else {
@@ -390,26 +390,3 @@ export default class DraftText extends Component {
     );
   }
 };
-
-function deepEqual(x, y) {
-  if ((typeof x == "object" && x != null) && (typeof y == "object" && y != null)) {
-    if (Object.keys(x).length != Object.keys(y).length)
-      return false;
-
-    for (let prop in x) {
-      if (y.hasOwnProperty(prop))
-      {
-        if (! deepEqual(x[prop], y[prop]))
-          return false;
-      }
-      else
-        return false;
-    }
-
-    return true;
-  }
-  else if (x !== y)
-    return false;
-  else
-    return true;
-}

--- a/server/meep-draft/draft-text.react.js
+++ b/server/meep-draft/draft-text.react.js
@@ -261,6 +261,31 @@ export default class DraftText extends Component {
     this.onChange(moveSelectionToEnd(defaultEditorState));
   }
 
+  componentDidUpdate(prevProps, prevState) {
+    // 判斷每個block中文字的style是否改變，是的話：call onEditorChange()
+    let thisBlockMap = this.state.editorState.toJS().currentContent.blockMap;
+    let prevBlockMap = prevState.editorState.toJS().currentContent.blockMap;
+    let isStyleChanged;
+    if(Object.keys(thisBlockMap).length === Object.keys(prevBlockMap).length) {
+      // no newline
+      Object.keys(thisBlockMap).map(key => {
+        if(thisBlockMap[key].text === prevBlockMap[key].text && !deepEqual(thisBlockMap[key].characterList, prevBlockMap[key].characterList)) {
+          // style change
+          isStyleChanged = true;
+        } else {
+          // the text of this block is changed
+          isStyleChanged = false;
+        }
+      })
+    } else {
+      // type newline
+      isStyleChanged = false;
+    }
+    if(this.props.onEditorChange && isStyleChanged) {
+      return this.getConvertToRaw(this.props.onEditorChange)
+    }
+  }
+
   render() {
     const {
        editorState,
@@ -365,3 +390,26 @@ export default class DraftText extends Component {
     );
   }
 };
+
+function deepEqual(x, y) {
+  if ((typeof x == "object" && x != null) && (typeof y == "object" && y != null)) {
+    if (Object.keys(x).length != Object.keys(y).length)
+      return false;
+
+    for (let prop in x) {
+      if (y.hasOwnProperty(prop))
+      {
+        if (! deepEqual(x[prop], y[prop]))
+          return false;
+      }
+      else
+        return false;
+    }
+
+    return true;
+  }
+  else if (x !== y)
+    return false;
+  else
+    return true;
+}


### PR DESCRIPTION
修正 ticket-202: 後台"商品描述"編輯後無法儲存

解法：
1. 在componentDidUpdate() 判斷 內容的style是否有被改變，有的話就call onEditChange()
2. 一樣保留 onBlur: 如果改變的不是style而是文字數量或多一個block，則在componentDidUpdate()中就不會call onEditChange()，當onBlur才call onEditChange()